### PR TITLE
Prepare release of v0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,19 +9,19 @@ rust-version = "1.85"
 exclude = [".github/"]
 readme = "README.md"
 name = "windows-native-keyring-store"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 
 [dependencies]
-keyring-core = { version = "0.7" }
-byteorder = "1.2"
-regex = "1.12"
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security_Credentials"] }
-zeroize = "1.8.1"
+keyring-core = { version = "0.7.2" }
+byteorder = "1.5.0"
+regex = "1.12.2"
+windows-sys = { version = "0.61.2", features = ["Win32_Foundation", "Win32_Security_Credentials"] }
+zeroize = "1.8.2"
 
 [dev-dependencies]
-fastrand = "2.3"
+fastrand = "2.3.0"
 sscanf = "0.4.4"
 
 [package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
+targets = ["x86_64-pc-windows-msvc"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,21 +42,21 @@ but you can specify a desired persistence by using the `persistence` modifier at
 creation time with a (case-insensitive) value of `Session`, `Local`, or `Enterprise`. Note
 that this type will only be applied when the credential's secret is written; it does not
 control the persistence of an existing credential in the store whose value is read via the entry.
-
-The persistence of an existing credential can be read and updated via its `persistence` attribute.
-Note that updating this attribute on an existing credential does `not` update the remembered
-persistence in the entry used to access that credential. Thus, setting the secret in a credential
-always changes its persistence to match that specified when the entry was created.
+The persistence of an existing credential can be read via its `persistence` attribute.
 
 ## Attributes
 
 In addition to the `persistence` attribute mentioned in the last section,
-there are three string attributes that are held on each generic credential:
-`target_alias`, `username`, and `comment`. The `username` attribute will be set
-from the `user` specifier whenever an entry is written.
-All four attributes on existing credentials can be read and set using the
-[get_attributes](keyring_core::Entry::get_attributes) and
-[update_attributes](keyring_core::Entry::update_attributes) methods.
+there are four string attributes that are held on each generic credential:
+`target_name`, `target_alias`, `username`, and `comment`.
+The `target_name` attribute is read-only (because it's the unique ID
+for the credential in the store).
+The `username` attribute in an entry created from a specifier will start
+off as the specifier's `user`.
+All the attributes on existing credentials can be read using the
+[get_attributes](keyring_core::Entry::get_attributes) method, and
+their writeable attributes can be set using the
+[update_attributes](keyring_core::Entry::update_attributes) method.
 
 ## Search
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -451,21 +451,6 @@ fn test_credential_persistence() {
         mock_session.get_attributes().unwrap()["persistence"],
         "Session"
     );
-    local
-        .update_attributes(&HashMap::from([("persistence", "Enterprise")]))
-        .unwrap();
-    assert_eq!(local.get_attributes().unwrap()["persistence"], "Enterprise");
-    assert_ne!(
-        local.as_any().downcast_ref::<Cred>().unwrap().persistence,
-        local
-            .get_credential()
-            .unwrap()
-            .as_any()
-            .downcast_ref::<Cred>()
-            .unwrap()
-            .persistence
-    );
-    assert_eq!(local.get_password().unwrap(), "local");
     mock_session.delete_credential().unwrap();
     session.delete_credential().unwrap_err();
     local.delete_credential().unwrap();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -259,10 +259,8 @@ pub fn cred_from_credential(credential: &mut CREDENTIALW) -> Cred {
         _ => CredPersist::Enterprise,
     };
     let target_name = unsafe { from_wstr(credential.TargetName) };
-    let user = unsafe { from_wstr(credential.UserName) };
     Cred {
         target_name,
-        user,
         specifiers: None,
         persistence,
     }
@@ -307,6 +305,9 @@ pub fn extract_secret(credential: &CREDENTIALW) -> Result<Vec<u8>> {
 /// A metadata extractor for use with [extract_from_credential].
 pub fn extract_attributes(credential: &CREDENTIALW) -> Result<HashMap<String, String>> {
     let result = HashMap::from([
+        ("target_name".to_string(), unsafe {
+            from_wstr(credential.TargetName)
+        }),
         ("username".to_string(), unsafe {
             from_wstr(credential.UserName)
         }),


### PR DESCRIPTION
This release enhances the handling of attributes, adding the `target_name` attribute which is needed to inspect wrappers properly. It's a breaking API change because the `persistence` attribute is now read-only.