### PR TITLE
Make `regex` optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2024"
 [dependencies]
 keyring-core = { version = "1" }
 byteorder = "1"
-regex = "1"
+regex = { version = "1", optional = true }
 windows-sys = { version = "0.61.2", features = ["Win32_Foundation", "Win32_Security_Credentials"] }
 zeroize = "1"
 
@@ -25,3 +25,7 @@ sscanf = "0.5"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-pc-windows-msvc"]
+
+[features]
+default = ["search"]
+search = ["dep:regex"]

--- a/src/store.rs
+++ b/src/store.rs
@@ -4,10 +4,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use keyring_core::api::{CredentialPersistence, CredentialStoreApi};
 use keyring_core::attributes::parse_attributes;
-use keyring_core::{Entry, Error, Result};
+use keyring_core::{Entry, Result};
 
 use crate::cred::Cred;
-use crate::utils::enumerate_credentials;
 
 /// The store for Windows native credentials
 #[derive(Clone)]
@@ -132,7 +131,11 @@ impl CredentialStoreApi for Store {
     }
 
     /// See the keyring-core API docs.
+    #[cfg(feature = "search")]
     fn search(&self, spec: &HashMap<&str, &str>) -> Result<Vec<Entry>> {
+        use crate::utils::enumerate_credentials;
+        use keyring_core::Error;
+
         let spec = parse_attributes(&["pattern"], Some(spec))?;
         let expr = if let Some(val) = spec.get("pattern") {
             if let Ok(pat) = regex::Regex::new(val) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,14 +6,17 @@ use windows_sys::Win32::Foundation::{
     ERROR_BAD_USERNAME, ERROR_INVALID_FLAGS, ERROR_INVALID_PARAMETER, ERROR_NO_SUCH_LOGON_SESSION,
     ERROR_NOT_FOUND, FILETIME, GetLastError,
 };
+#[cfg(feature = "search")]
+use windows_sys::Win32::Security::Credentials::CredEnumerateW;
 use windows_sys::Win32::Security::Credentials::{
     CRED_FLAGS, CRED_MAX_CREDENTIAL_BLOB_SIZE, CRED_MAX_GENERIC_TARGET_NAME_LENGTH,
     CRED_MAX_STRING_LENGTH, CRED_MAX_USERNAME_LENGTH, CRED_PERSIST, CRED_PERSIST_ENTERPRISE,
     CRED_PERSIST_LOCAL_MACHINE, CRED_PERSIST_SESSION, CRED_TYPE_GENERIC, CREDENTIAL_ATTRIBUTEW,
-    CREDENTIALW, CredDeleteW, CredEnumerateW, CredFree, CredReadW, CredWriteW,
+    CREDENTIALW, CredDeleteW, CredFree, CredReadW, CredWriteW,
 };
 use zeroize::Zeroize;
 
+#[cfg(feature = "search")]
 use crate::cred::Cred;
 use keyring_core::error::{Error, Result};
 
@@ -182,6 +185,7 @@ pub fn delete_credential(target_name: &str) -> Result<()> {
 }
 
 /// Enumerate generic credentials
+#[cfg(feature = "search")]
 pub fn enumerate_credentials(
     pattern: Option<regex::Regex>,
     delimiters: &[String; 3],
@@ -251,6 +255,7 @@ where
 }
 
 /// get a Cred from a native credential
+#[cfg(feature = "search")]
 pub fn cred_from_credential(credential: &mut CREDENTIALW) -> Cred {
     erase_secret(credential); // erase the secret, so it won't be leaked into the heap
     let persistence = match credential.Persist {


### PR DESCRIPTION
Closes #9 

This PR makes `regex` optional, and enabled by default.